### PR TITLE
Fixed #3 utilise page-specific content for custom columns

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,16 +22,16 @@
 
 			{% if secondary-column == 'left' %}
 			<div class="secondary-column">
-				<div class="secondary-column-content">{% include secondary-column.html %}</div>
+				<div class="secondary-column-content">{% include {{ secondary-column-content }} %}</div>
 				{% if tertiary-column == 'present' %}	
-					<div class="tertiary-column-content">{% include tertiary-column.html %}</div>
+					<div class="tertiary-column-content">{% include {{ tertiary-column-content }} %}</div>
 				{% endif %}
 			</div>
 			<div class="secondary-divider"></div>
 			{% else %}
 				{% if tertiary-column == 'present' %}
 				<div class="tertiary-column">
-					<div class="tertiary-column-content">{% include tertiary-column.html %}</div>
+					<div class="tertiary-column-content">{% include {{ tertiary-column-content }} %}</div>
 				</div>
 				<div class="tertiary-divider"></div>
 				{% endif %}			
@@ -53,16 +53,16 @@
 			{% if secondary-column == 'right' %}
 			<div class="secondary-divider"></div>			
 			<div class="secondary-column">
-				<div class="secondary-column-content">{% include secondary-column.html %}</div>
+				<div class="secondary-column-content">{% include {{ secondary-column-content }} %}</div>
 				{% if tertiary-column == 'present' %}	
-					<div class="tertiary-column-content">{% include tertiary-column.html %}</div>
+					<div class="tertiary-column-content">{% include {{ tertiary-column-content }} %}</div>
 				{% endif %}
 			</div>
 			{% else %}
 			   {% if tertiary-column == 'present' %}
 				<div class="tertiary-divider"></div>
 				<div class="tertiary-column">
-					<div class="tertiary-column-content">{% include tertiary-column.html %}</div>
+					<div class="tertiary-column-content">{% include {{ tertiary-column-content }} %}</div>
 				</div>
 				{% endif %}
 			{% endif %}


### PR DESCRIPTION
In _layouts/default.html the liguid
variables are computed reliably for
the ”*-column-content" files.
Use those instead of the hard-coded
default filename.