### PR TITLE
Require at least Jekyll `v3.5.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Change in the Gemfile:
 Change in the `_config.yml`:
 
 	From `theme: minima` to `theme: classic-jekyll-theme`
-	Add `jekyll-data` to the gems.
 
 Delete the file `about.md`:
 

--- a/_config.yml
+++ b/_config.yml
@@ -27,9 +27,5 @@ github_username:  jekyll
 # Build settings
 markdown: kramdown
 theme: classic-jekyll-theme
-plugins_dir:
+plugins:
   - jekyll-feed
-  - jekyll-data
-exclude:
-  - Gemfile
-  - Gemfile.lock

--- a/classic-jekyll-theme.gemspec
+++ b/classic-jekyll-theme.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|pages|_layouts|_includes|_sass|_data|LICENSE|README|navbanner)}i) }
   
+  spec.add_runtime_dependency "jekyll", "~> 3.5", ">= 3.5.1"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.8"
   spec.add_runtime_dependency "jekyll-data", "~> 0.4"
   
-  spec.add_development_dependency "jekyll", "~> 3.3"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
 - Jekyll 3.5.0 and beyond will automatically require a theme's runtime dependencies. So there's no need of specifying gem-only* plugins in the config file.
 - The new name for `gems` key is `plugins` not `plugins_dir`, which is used to configure local plugins directory ( default: `./_plugins` )
 - Jekyll 3.5.0 contained some bad bugs which was readily fixed in `v3.5.1`
 - `Gemfile` and `Gemfile.lock` is excluded by default from `v3.5.0`

---

*gem-only plugin refers to a plugin that is not required if a user forks
the theme's repo.