### PR TITLE
Relax version constraint on jekyll-data plugin

### DIFF
--- a/classic-jekyll-theme.gemspec
+++ b/classic-jekyll-theme.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|pages|_layouts|_includes|_sass|_data|LICENSE|README|navbanner)}i) }
   
   spec.add_runtime_dependency "jekyll-feed", "~> 0.8"
-  spec.add_runtime_dependency "jekyll-data", "~> 0.4"
+  spec.add_runtime_dependency "jekyll-data", ">= 0.4", "< 2.0"
   
   spec.add_development_dependency "jekyll", "~> 3.3"
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
allow users to use any version of the plugin starting from v0.4 but not from the future 2.0 series which may contain breaking changes