### PR TITLE
Fix html validation - whitespace in "id" attributes

### DIFF
--- a/_includes/menubar.html
+++ b/_includes/menubar.html
@@ -141,9 +141,9 @@
 		{%- endif -%}
 
 		{%- comment -%}<!-- Create top menu item -->{%- endcomment %}
-		<input type="checkbox" id="{{ topTitle | append:'-checkbox'}}">
+		<input type="checkbox" id="{{ topTitle | replace:' ','-' | append:'-checkbox'}}">
 		<div class="title">
-			<label class="symbol" for="{{ topTitle | append:'-checkbox'}}">
+			<label class="symbol" for="{{ topTitle | replace:' ','-' | append:'-checkbox'}}">
 		{%- if sortedSubMenuTitles.size > 0 %}
 				<p class="code"><!-- will be filled by disclosure indicator --></p>
 		{%- else %}
@@ -287,9 +287,9 @@
 			<div class="subitem">
 							{%- endif -%}
 						{%- endif %}
-				<input type="checkbox" id="{{ subMenuTitle | append:'-checkbox'}}">
+				<input type="checkbox" id="{{ subMenuTitle | replace:' ','-' | append:'-checkbox'}}">
 				<div class="title">
-					<label class="symbol" for="{{ subMenuTitle | append:'-checkbox'}}">
+					<label class="symbol" for="{{ subMenuTitle | replace:' ','-' | append:'-checkbox'}}">
 						{%- if sortedSubsubMenuTitles.size > 0 %}
 						<p class="code"><!-- will be filled by disclosure indicator --></p>
 						{%- else %}
@@ -310,9 +310,9 @@
 						{%- else %}
 			<div class="subitem">
 						{%- endif %}
-				<input type="checkbox" id="{{ subMenuTitle | append:'-checkbox'}}">
+				<input type="checkbox" id="{{ subMenuTitle | replace:' ','-' | append:'-checkbox'}}">
 				<div class="title">
-					<label class="symbol" for="{{ subMenuTitle | append:'-checkbox'}}">
+					<label class="symbol" for="{{ subMenuTitle | replace:' ','-' | append:'-checkbox'}}">
 						{%- if sortedSubsubMenuTitles.size > 0 %}
 						<p class="code"><!-- will be filled by disclosure indicator --></p>
 						{%- else %}

--- a/_includes/vertical-menu.html
+++ b/_includes/vertical-menu.html
@@ -219,11 +219,11 @@
 			</div>
 			{%- endif -%}
 		{%- else %}
-			<input type="checkbox" id="{{ subMenuTitle | append:'-vmenu-' | append: include.label-modifier }}">
+			<input type="checkbox" id="{{ subMenuTitle | replace:' ','-' | append:'-vmenu-' | append: include.label-modifier }}">
 			{%- if sortedSubMenuLinks[forloop.index0] != false -%}
 				{%- if sortedSubMenuUrls[forloop.index0] == page.url %}
 			<div class="sub-isActivePage">
-				<label class="disclosure show-hover" for="{{ subMenuTitle | append:'-vmenu-' | append: include.label-modifier }}">
+				<label class="disclosure show-hover" for="{{ subMenuTitle | replace:' ','-' | append:'-vmenu-' | append: include.label-modifier }}">
 					<p class="symbol"><!-- will be filled by disclosure indicator --></p>
 				</label>
 				<div class="title">
@@ -232,7 +232,7 @@
 			</div>
 				{%- else %}
 			<div class="sub-hasLink">
-				<label class="disclosure show-hover" for="{{ subMenuTitle | append:'-vmenu-' | append: include.label-modifier }}">
+				<label class="disclosure show-hover" for="{{ subMenuTitle | replace:' ','-' | append:'-vmenu-' | append: include.label-modifier }}">
 					<p class="symbol"><!-- will be filled by disclosure indicator --></p>
 				</label>
 				<div class="title">
@@ -242,7 +242,7 @@
 				{%- endif -%}
 			{%- else %}
 			<div class="sub">
-				<label class="disclosure show-hover" for="{{ subMenuTitle | append:'-vmenu-' | append: include.label-modifier }}">
+				<label class="disclosure show-hover" for="{{ subMenuTitle | replace:' ','-' | append:'-vmenu-' | append: include.label-modifier }}">
 					<p class="symbol"><!-- will be filled by disclosure indicator --></p>
 				</label>
 				<div class="title"><p>{{ subMenuTitle }}</p></div>


### PR DESCRIPTION
Validating the site with validator.w3.org does report some errors. One class of issue is:

```
Bad value "About Menu Items-checkbox" for attribute "id" on element "input": An ID must not contain whitespace.
Bad value "About Menu Items-checkbox" for attribute "for" on element "label": An ID must not contain whitespace.
```

Fixed that using Liquid "replace:".